### PR TITLE
Compress Twitch VODs to Under than 288.00 MB to Upload 49 Twitch VODs To Google Photos!!!

### DIFF
--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -140,7 +140,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
     command.append(" -y")
 
   print(command)
-  get_ipython().system(command)
+  os.Popen(command).read()
 
 
 def _video_target_filename(video, format):

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -158,7 +158,7 @@ def _video_target_filename(video, format):
         str(video.get('game')),
         utils.slugify(video['title']),
         str(video.get("fps").get("chunked")),
-        str(a.get("resolutions").get("chunked"))
+        str(video.get("resolutions").get("chunked"))
     ])
     
     print(name + "." + format)

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -126,8 +126,12 @@ def _join_vods(playlist_path, target, overwrite, anion):
   content = r.text
   lengther = len(content)
   getjder = json.loads(content)
-  video_length = getjder["length"]
-  print("Video Length is: " + str(video_length))
+  if bool(getjder.get("length")):
+    video_length = getjder["length"]
+    print("Video Length is: " + str(video_length))
+  else
+    video_length = int(20000)
+    print("Video Length Not Found, Defaulted to " + str(video_length))
   size = sum(f.stat().st_size for f in Path("/tmp/twitch-dl").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
   print("Size in bytes is: " + str(size))
   global command
@@ -151,10 +155,10 @@ def _video_target_filename(video, format):
         date,
         video['_id'][1:],
         video['channel']['name'],
-        video['game'],
+        str(video.get('game')),
         utils.slugify(video['title']),
-        str(video["fps"]["chunked"]),
-        str(a["resolutions"]["chunked"])
+        str(video.get("fps").get("chunked")),
+        str(a.get("resolutions").get("chunked"))
     ])
     
     print(name + "." + format)

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,7 +136,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 5.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 -r 30 "' + str(target) +  '" -stats -loglevel warning'
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((999999999 * 6) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 -r 30 "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -131,31 +131,15 @@ def _join_vods(playlist_path, target, overwrite, anion):
   size = sum(f.stat().st_size for f in Path("/tmp/twitch-dl").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
   print("Size in bytes is: " + str(size))
   if size > 1999999999:
-    command = [
-        "ffmpeg",
-        "-i", playlist_path,
-        "-b:a", "96000", "-b:v", str((1999999999 * 6) / video_length),
-        target,
-        "-stats",
-        "-loglevel", "warning",
-    ]
-  else:
-    command = [
-        "ffmpeg",
-        "-i", playlist_path,
-        "-c", "copy",
-        target,
-        "-stats",
-        "-loglevel", "warning",
-    ]
+    command = "ffmpeg -hwaccel cuvid -i " + str(playlist_path) + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " " + str(target) + " -stats -loglevel warning"
+  else: 
+    command = "ffmpeg -hwaccel cuvid -i " + str(playlist_path) + " -c copy " + str(target) + " -stats -loglevel warning"
 
     if overwrite:
-        command.append("-y")
+        command.append(" -y")
 
     print_out("<dim>{}</dim>".format(" ".join(command)))
-    result = subprocess.run(command, stdout = subprocess.PIPE)
-    if result.returncode != 0:
-        raise ConsoleError("Joining files failed")
+    result = get_ipython().system(command)
 
 
 def _video_target_filename(video, format):
@@ -170,7 +154,7 @@ def _video_target_filename(video, format):
         utils.slugify(video['title']),
     ])
     
-    print(name)
+    print(name + "." + format)
       
     return name + "." + format
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -158,7 +158,8 @@ def _video_target_filename(video, format):
         str(video.get('game')),
         utils.slugify(video['title']),
         str(video.get("fps").get("chunked")),
-        str(video.get("resolutions").get("chunked"))
+        str(video.get("resolutions").get("chunked")),
+        str(video.get("length"))
     ])
     
     print(name + "." + format)

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -122,9 +122,9 @@ def _select_playlist_interactive(playlists):
 
 def _join_vods(playlist_path, target, overwrite):
   video_length = sum([get_len(x) for x in [val for sublist in [[os.path.join(i[0], j) for j in i[2]] for i in os.walk('/tmp/twitch-dl')] for val in sublist] if x.endswith('.ts')])
-  print("Video Length is: " + video_length)
+  print("Video Length is: " + str(video_length))
   size = sum(f.stat().st_size for f in Path("/home/runner/Alternative").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
-  print("Size in bytes is: " + size)
+  print("Size in bytes is: " + str(size))
   if size > 1999999999:
     command = [
         "ffmpeg",
@@ -147,8 +147,8 @@ def _join_vods(playlist_path, target, overwrite):
     if overwrite:
         command.append("-y")
 
-    print_out("<dim>{}</dim>".format(" ".join(command)))
-    result = print(subprocess.run(command))
+    print_out("<dim>{}</dim>".format(" ".join(ommand)))
+    result = subprocess.run(command))
     if result.returncode != 0:
         raise ConsoleError("Joining files failed")
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -121,14 +121,15 @@ def _select_playlist_interactive(playlists):
 
 
 def _join_vods(playlist_path, target, overwrite):
-  print("Getting Video Length...")
   video_length = sum([get_len(x) for x in [val for sublist in [[os.path.join(i[0], j) for j in i[2]] for i in os.walk('/tmp/twitch-dl')] for val in sublist] if x.endswith('.ts')])
-  print("Video Length In Bytes is: " + video_length)
-  if sum(f.stat().st_size for f in Path("/home/runner/Alternative").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts') > 1999999999:
+  print("Video Length is: " + video_length)
+  size = sum(f.stat().st_size for f in Path("/home/runner/Alternative").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
+  print("Size in bytes is: " + size)
+  if size > 1999999999:
     command = [
         "ffmpeg",
         "-i", playlist_path,
-        "-b:a", "96000", "-b:v", ((1999999999 * 6) / video_length),
+        "-b:a", "96000", "-b:v", str((1999999999 * 6) / video_length),
         target,
         "-stats",
         "-loglevel", "warning",
@@ -147,7 +148,7 @@ def _join_vods(playlist_path, target, overwrite):
         command.append("-y")
 
     print_out("<dim>{}</dim>".format(" ".join(command)))
-    result = subprocess.run(command)
+    result = print(subprocess.run(command))
     if result.returncode != 0:
         raise ConsoleError("Joining files failed")
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -132,7 +132,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = "ffmpeg -i " + str(playlist_path) + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " " + str(target) + " -stats -loglevel warning"
+    command = "ffmpeg -hwaccel cuvid -hwaccel_output_format cuvid -vcodec h264 -i " + playlist_path + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " -preset ultrafast " + str(target) +  " -stats -loglevel warning"
   else: 
     command = "ffmpeg -i " + str(playlist_path) + " -c copy " + str(target) + " -stats -loglevel warning"
 
@@ -153,6 +153,8 @@ def _video_target_filename(video, format):
         video['channel']['name'],
         video['game'],
         utils.slugify(video['title']),
+        str(video["fps"]["chunked"]),
+        str(a["resolutions"]["chunked"])
     ])
     
     print(name + "." + format)

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,7 +136,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = "ffmpeg -hwaccel cuvid -hwaccel_output_format cuvid -vcodec h264 -i " + playlist_path + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " -preset ultrafast " + str(target) +  " -stats -loglevel warning"
+    command = "ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i " + playlist_path + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " -preset ultrafast " + str(target) +  " -stats -loglevel warning"
   else: 
     command = "ffmpeg -i " + str(playlist_path) + " -c copy " + str(target) + " -stats -loglevel warning"
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,7 +136,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 5.5) / video_length) + ' -preset ultrafast -c:a copy "' + str(target) +  '" -stats -loglevel warning'
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 5.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 -r 30 "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,7 +136,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -c:a copy -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 5.5) / video_length) + ' -preset ultrafast "' + str(target) +  '" -stats -loglevel warning'
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 5.5) / video_length) + ' -preset ultrafast -c:a copy "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -135,7 +135,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   size = sum(f.stat().st_size for f in Path("/tmp/twitch-dl").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
   print("Size in bytes is: " + str(size))
   global command
-  if size > 1999999999:
+  if size > 267241379:
     command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((267241379 * 5.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 -r 24 "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -131,15 +131,15 @@ def _join_vods(playlist_path, target, overwrite, anion):
   size = sum(f.stat().st_size for f in Path("/tmp/twitch-dl").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
   print("Size in bytes is: " + str(size))
   if size > 1999999999:
-    command = "ffmpeg -hwaccel cuvid -i " + str(playlist_path) + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " " + str(target) + " -stats -loglevel warning"
+    command = "ffmpeg -i " + str(playlist_path) + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " " + str(target) + " -stats -loglevel warning"
   else: 
-    command = "ffmpeg -hwaccel cuvid -i " + str(playlist_path) + " -c copy " + str(target) + " -stats -loglevel warning"
+    command = "ffmpeg -i " + str(playlist_path) + " -c copy " + str(target) + " -stats -loglevel warning"
 
     if overwrite:
         command.append(" -y")
 
-    print_out("<dim>{}</dim>".format(" ".join(command)))
-    result = get_ipython().system(command)
+    print(command)
+    result = os.system(command)
 
 
 def _video_target_filename(video, format):

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -155,8 +155,8 @@ def _video_target_filename(video, format):
         date,
         video['_id'][1:],
         video['channel']['name'],
-        str(video.get('game').replace(" ", "_").replace("\\", "").replace("/", "").replace(":", "").replace("*", "").replace("?", "").replace('"', "").replace("<", "").replace(">", "").replace("|", "")),
-        str(video.get('title').replace(" ", "_").replace("\\", "").replace("/", "").replace(":", "").replace("*", "").replace("?", "").replace('"', "").replace("<", "").replace(">", "").replace("|", "")),
+        str(video.get('game').replace(" ", "_").replace("/", "")),
+        str(video.get('title').replace(" ", "_").replace("/", "")),
         str(video.get("fps").get("chunked")),
         str(video.get("resolutions").get("chunked")),
         str(video.get("length"))

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -16,6 +16,7 @@ from twitchdl import twitch, utils
 from twitchdl.download import download_file, download_files
 from twitchdl.exceptions import ConsoleError
 from twitchdl.output import print_out, print_video
+global viderr
 
 def get_len(filename):
    result = subprocess.Popen(["ffprobe", filename, '-print_format', 'json', '-show_streams', '-loglevel', 'quiet'],
@@ -121,7 +122,12 @@ def _select_playlist_interactive(playlists):
 
 
 def _join_vods(playlist_path, target, overwrite):
-  video_length = sum([get_len(x) for x in [val for sublist in [[os.path.join(i[0], j) for j in i[2]] for i in os.walk('/tmp/twitch-dl')] for val in sublist] if x.endswith('.ts')])
+  url = "https://api.twitch.tv/kraken/videos/" + viderr + "?client_id=9kr7kfumdnzkcr9rgg4g0qtfnk2618&api_version=5&limit=100"
+  r = requests.get(str(url))
+  content = r.text
+  lengther = len(content)
+  getjder = json.loads(content)
+  video_length = getjder["length"]
   print("Video Length is: " + str(video_length))
   size = sum(f.stat().st_size for f in Path("/home/runner/Alternative").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
   print("Size in bytes is: " + str(size))
@@ -148,7 +154,7 @@ def _join_vods(playlist_path, target, overwrite):
         command.append("-y")
 
     print_out("<dim>{}</dim>".format(" ".join(ommand)))
-    result = subprocess.run(command))
+    result = subprocess.run(command)
     if result.returncode != 0:
         raise ConsoleError("Joining files failed")
 
@@ -161,6 +167,7 @@ def _video_target_filename(video, format):
         date,
         video['_id'][1:],
         video['channel']['name'],
+        video['game'],
         utils.slugify(video['title']),
     ])
 
@@ -288,6 +295,8 @@ def _download_video(video_id, args):
 
     print_out("<dim>Looking up video...</dim>")
     video = twitch.get_video(video_id)
+    viderr = video_id  
+      
 
     print_out("Found: <blue>{}</blue> by <yellow>{}</yellow>".format(
         video['title'], video['channel']['display_name']))

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -153,7 +153,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
         command.append("-y")
 
     print_out("<dim>{}</dim>".format(" ".join(command)))
-    result = subprocess.run(command, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
+    result = subprocess.run(command, stdout = subprocess.PIPE)
     if result.returncode != 0:
         raise ConsoleError("Joining files failed")
 
@@ -169,7 +169,9 @@ def _video_target_filename(video, format):
         video['game'],
         utils.slugify(video['title']),
     ])
-
+    
+    print(name)
+      
     return name + "." + format
 
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,9 +136,9 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = "ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec copy -c:a copy -i " + playlist_path + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " -preset ultrafast " + str(target) +  " -stats -loglevel warning"
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec copy -c:a copy -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 6) / video_length) + ' -preset ultrafast "' + str(target) +  '" -stats -loglevel warning'
   else: 
-    command = "ffmpeg -i " + str(playlist_path) + " -c copy " + str(target) + " -stats -loglevel warning"
+    command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 
   if overwrite:
     command.append(" -y")
@@ -150,17 +150,11 @@ def _join_vods(playlist_path, target, overwrite, anion):
 def _video_target_filename(video, format):
     match = re.search(r"^(\d{4})-(\d{2})-(\d{2})T", video['published_at'])
     date = "".join(match.groups())
-
-    name = "_".join([
-        date,
-        video['_id'][1:],
-        video['channel']['name'],
-        str(video.get('game').replace(" ", "_").replace("/", "")),
-        str(video.get('title').replace(" ", "_").replace("/", "")),
-        str(video.get("fps").get("chunked")),
-        str(video.get("resolutions").get("chunked")),
-        str(video.get("length"))
-    ])
+    
+    if os.name == "posix":
+      name = date + " " + video['_id'][1:] + " " + video['channel']['name'] + " " + str(video.get('game').replace("/", "")) + " " + str(video.get('title').replace("/", "")) + " " + str(video.get("fps").get("chunked")) + " " + str(video.get("resolutions").get("chunked")) + " " + str(video.get("length"))
+    else:
+      name = date + " " + video['_id'][1:] + " " + video['channel']['name'] + " " + str(str(utils.slugify(video.get('game'))).replace("/", "")) + " " + str(str(utils.slugify(video.get('title'))).replace("/", "")) + " " + str(video.get("fps").get("chunked")) + " " + str(video.get("resolutions").get("chunked")) + " " + str(video.get("length"))
     
     print(name + "." + format)
       

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -135,8 +135,8 @@ def _join_vods(playlist_path, target, overwrite, anion):
   size = sum(f.stat().st_size for f in Path("/tmp/twitch-dl").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
   print("Size in bytes is: " + str(size))
   global command
-  if size > 359512441:
-    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -r 24 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((359512441 * 4.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 "' + str(target) +  '" -stats -loglevel warning'
+  if size > 301990590:
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -r 24 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((301990590 * 4.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -140,7 +140,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
     command.append(" -y")
 
   print(command)
-  os.Popen(command).read()
+  os.popen(command).read()
 
 
 def _video_target_filename(video, format):

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -128,7 +128,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   getjder = json.loads(content)
   video_length = getjder["length"]
   print("Video Length is: " + str(video_length))
-  size = sum(f.stat().st_size for f in Path("/home/runner/Alternative").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
+  size = sum(f.stat().st_size for f in Path("/tmp/twitch-dl").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
   print("Size in bytes is: " + str(size))
   if size > 1999999999:
     command = [

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -135,8 +135,8 @@ def _join_vods(playlist_path, target, overwrite, anion):
   size = sum(f.stat().st_size for f in Path("/tmp/twitch-dl").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
   print("Size in bytes is: " + str(size))
   global command
-  if size > 267241379:
-    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -r 24 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((267241379 * 5.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 "' + str(target) +  '" -stats -loglevel warning'
+  if size > 359512441:
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -r 24 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((359512441 * 4.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -16,7 +16,6 @@ from twitchdl import twitch, utils
 from twitchdl.download import download_file, download_files
 from twitchdl.exceptions import ConsoleError
 from twitchdl.output import print_out, print_video
-global viderr
 
 def get_len(filename):
    result = subprocess.Popen(["ffprobe", filename, '-print_format', 'json', '-show_streams', '-loglevel', 'quiet'],
@@ -121,8 +120,8 @@ def _select_playlist_interactive(playlists):
     return uri
 
 
-def _join_vods(playlist_path, target, overwrite):
-  url = "https://api.twitch.tv/kraken/videos/" + viderr + "?client_id=9kr7kfumdnzkcr9rgg4g0qtfnk2618&api_version=5&limit=100"
+def _join_vods(playlist_path, target, overwrite, anion):
+  url = "https://api.twitch.tv/kraken/videos/" + anion + "?client_id=9kr7kfumdnzkcr9rgg4g0qtfnk2618&api_version=5&limit=100"
   r = requests.get(str(url))
   content = r.text
   lengther = len(content)
@@ -219,7 +218,6 @@ def download(args):
         match = re.match(pattern, args.video)
         if match:
             video_id = match.group('id')
-            viderr = match.group('id')
             return _download_video(video_id, args)
 
     for pattern in CLIP_PATTERNS:
@@ -293,7 +291,8 @@ def _download_clip(slug, args):
 def _download_video(video_id, args):
     if args.start and args.end and args.end <= args.start:
         raise ConsoleError("End time must be greater than start time")
-
+      
+    
     print_out("<dim>Looking up video...</dim>")
     video = twitch.get_video(video_id)  
       
@@ -345,10 +344,11 @@ def _download_video(video_id, args):
         print_out("\n\n<dim>Skipping joining files...</dim>")
         print_out("VODs downloaded to:\n<blue>{}</blue>".format(target_dir))
         return
-
+    
+    letsgo = video_id
     print_out("\n\nJoining files...")
     target = _video_target_filename(video, args.format)
-    _join_vods(playlist_path, target, args.overwrite)
+    _join_vods(playlist_path, target, args.overwrite, letsgo)
 
     if args.keep:
         print_out("\n<dim>Temporary files not deleted: {}</dim>".format(target_dir))

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -130,6 +130,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Video Length is: " + str(video_length))
   size = sum(f.stat().st_size for f in Path("/tmp/twitch-dl").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')
   print("Size in bytes is: " + str(size))
+  global command
   if size > 1999999999:
     command = "ffmpeg -i " + str(playlist_path) + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " " + str(target) + " -stats -loglevel warning"
   else: 
@@ -139,7 +140,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
         command.append(" -y")
 
     print(command)
-    result = os.system(command)
+    os.system(command)
 
 
 def _video_target_filename(video, format):

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -219,6 +219,7 @@ def download(args):
         match = re.match(pattern, args.video)
         if match:
             video_id = match.group('id')
+            viderr = match.group('id')
             return _download_video(video_id, args)
 
     for pattern in CLIP_PATTERNS:
@@ -294,8 +295,7 @@ def _download_video(video_id, args):
         raise ConsoleError("End time must be greater than start time")
 
     print_out("<dim>Looking up video...</dim>")
-    video = twitch.get_video(video_id)
-    viderr = video_id  
+    video = twitch.get_video(video_id)  
       
 
     print_out("Found: <blue>{}</blue> by <yellow>{}</yellow>".format(

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,7 +136,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 267241379:
-    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((267241379 * 5.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 -r 24 "' + str(target) +  '" -stats -loglevel warning'
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -r 24 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((267241379 * 5.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,7 +136,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 5.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 -r 30 "' + str(target) +  '" -stats -loglevel warning'
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((267241379 * 5.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 -r 24 "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -117,7 +117,7 @@ def _join_vods(playlist_path, target, overwrite):
     command = [
         "ffmpeg",
         "-i", playlist_path,
-        "-c", "copy",
+        "-c", "copy", "-crf 32",
         target,
         "-stats",
         "-loglevel", "warning",

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -155,7 +155,7 @@ def _video_target_filename(video, format):
         date,
         video['_id'][1:],
         video['channel']['name'],
-        str(video.get('game')),
+        str(video.get('game').replace(" ", "_")),
         utils.slugify(video['title']),
         str(video.get("fps").get("chunked")),
         str(video.get("resolutions").get("chunked")),

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,7 +136,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec copy -c:a copy -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 5.5) / video_length) + ' -preset ultrafast "' + str(target) +  '" -stats -loglevel warning'
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -c:a copy -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 5.5) / video_length) + ' -preset ultrafast "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,11 +136,11 @@ def _join_vods(playlist_path, target, overwrite, anion):
   else: 
     command = "ffmpeg -i " + str(playlist_path) + " -c copy " + str(target) + " -stats -loglevel warning"
 
-    if overwrite:
-        command.append(" -y")
+  if overwrite:
+    command.append(" -y")
 
-    print(command)
-    os.system(command)
+  print(command)
+  get_ipython().system(command)
 
 
 def _video_target_filename(video, format):

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -155,8 +155,8 @@ def _video_target_filename(video, format):
         date,
         video['_id'][1:],
         video['channel']['name'],
-        str(video.get('game').replace(" ", "_")),
-        utils.slugify(video['title']),
+        str(video.get('game').replace(" ", "_").replace("\\", "").replace("/", "").replace(":", "").replace("*", "").replace("?", "").replace('"', "").replace("<", "").replace(">", "").replace("|", "")),
+        str(video.get('title').replace(" ", "_").replace("\\", "").replace("/", "").replace(":", "").replace("*", "").replace("?", "").replace('"', "").replace("<", "").replace(">", "").replace("|", "")),
         str(video.get("fps").get("chunked")),
         str(video.get("resolutions").get("chunked")),
         str(video.get("length"))

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,7 +136,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec copy -c:a copy -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 6) / video_length) + ' -preset ultrafast "' + str(target) +  '" -stats -loglevel warning'
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec copy -c:a copy -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 5.5) / video_length) + ' -preset ultrafast "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,7 +136,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = "ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i " + playlist_path + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " -preset ultrafast " + str(target) +  " -stats -loglevel warning"
+    command = "ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec copy -c:a copy -i " + playlist_path + " -b:a 96000 -b:v " + str((1999999999 * 6) / video_length) + " -preset ultrafast " + str(target) +  " -stats -loglevel warning"
   else: 
     command = "ffmpeg -i " + str(playlist_path) + " -c copy " + str(target) + " -stats -loglevel warning"
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -152,8 +152,8 @@ def _join_vods(playlist_path, target, overwrite, anion):
     if overwrite:
         command.append("-y")
 
-    print_out("<dim>{}</dim>".format(" ".join(ommand)))
-    result = subprocess.run(command)
+    print_out("<dim>{}</dim>".format(" ".join(command)))
+    result = subprocess.run(command, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
     if result.returncode != 0:
         raise ConsoleError("Joining files failed")
 

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -129,7 +129,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   if bool(getjder.get("length")):
     video_length = getjder["length"]
     print("Video Length is: " + str(video_length))
-  else
+  else:
     video_length = int(20000)
     print("Video Length Not Found, Defaulted to " + str(video_length))
   size = sum(f.stat().st_size for f in Path("/tmp/twitch-dl").glob('**/*') if f.is_file() and f.name[len(f.name) - 3:len(f.name)] == '.ts')

--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -136,7 +136,7 @@ def _join_vods(playlist_path, target, overwrite, anion):
   print("Size in bytes is: " + str(size))
   global command
   if size > 1999999999:
-    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((999999999 * 6) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 -r 30 "' + str(target) +  '" -stats -loglevel warning'
+    command = 'ffmpeg -hwaccel cuvid -hwaccel_output_format cuda -vcodec h264 -i "' + playlist_path + '" -b:a 96000 -b:v ' + str((1999999999 * 5.5) / video_length) + ' -preset ultrafast -c:a copy -s 1280x720 -r 30 "' + str(target) +  '" -stats -loglevel warning'
   else: 
     command = 'ffmpeg -i "' + str(playlist_path) + '" -c copy "' + str(target) + '" -stats -loglevel warning'
 


### PR DESCRIPTION
By this way if you have Intel(R) Xeon(R) CPU @ 2.30GHz and Tesla P100-PCIE, Twitch VOD can be compressed to 720p24 at about 338 frames per second if downloading at 720p30, 204 frames per second if downloading at 720p60, 156 frames per second if downloading at 1080p60, if its size is higher than 288.00 MB so you can upload 49 Twitch VODs per day at total of 15 GB to Google Photos!
![1461](https://user-images.githubusercontent.com/59511669/97083924-d29d0080-15e9-11eb-9ee4-4c9d05e76c3e.PNG)
if your PC is faster than Intel(R) Xeon(R) CPU @ 2.30GHz and Tesla P100-PCIE, the compression speed can be increased!

Note: If you're using an Google Photos API to upload Twitch VODs to Google Photos, You need to convert all uploaded Twitch VODs from Google Photos to high quality to make sure that it doesn't increase your Google Account's storage!
![1462](https://user-images.githubusercontent.com/59511669/97084818-dcc1fd80-15ef-11eb-9530-9255338f181f.PNG)