### PR TITLE
Fix bug in videos command saying there are more videos when there aren’t

### DIFF
--- a/twitchdl/commands.py
+++ b/twitchdl/commands.py
@@ -122,7 +122,7 @@ def videos(args):
         for video in videos["edges"]:
             print_video(video["node"])
 
-        if not args.pager:
+        if not args.pager and has_more:
             print_out(
                 "\n<dim>There are more videos. "
                 "Increase the --limit or use --pager to see the rest.</dim>"


### PR DESCRIPTION
When listing videos, if --pager was not specified and all of the videos
for a channel were listed, a message would still print out saying
“There are more videos. Increase the --limit or use --pager to see the
rest."

This checks to see if there are actually more videos before printing
that error message.