### PR TITLE
New clip naming

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -22,6 +22,10 @@ TEST_CLIP_PATTERNS = {
     ("HungryProudRadicchioDoggo", "https://clips.twitch.tv/HungryProudRadicchioDoggo"),
     ("HungryProudRadicchioDoggo", "https://www.twitch.tv/bananasaurus_rex/clip/HungryProudRadicchioDoggo?filter=clips&range=7d&sort=time"),
     ("HungryProudRadicchioDoggo", "https://twitch.tv/bananasaurus_rex/clip/HungryProudRadicchioDoggo?filter=clips&range=7d&sort=time"),
+    ("GloriousColdbloodedTortoiseRuleFive-E017utJ4DZmHVpfQ", "GloriousColdbloodedTortoiseRuleFive-E017utJ4DZmHVpfQ"),
+    ("GloriousColdbloodedTortoiseRuleFive-E017utJ4DZmHVpfQ", "https://twitch.tv/dracul1nx/clip/GloriousColdbloodedTortoiseRuleFive-E017utJ4DZmHVpfQ"),
+    ("GloriousColdbloodedTortoiseRuleFive-E017utJ4DZmHVpfQ", "https://twitch.tv/dracul1nx/clip/GloriousColdbloodedTortoiseRuleFive-E017utJ4DZmHVpfQ?filter=clips&range=7d&sort=time"),
+    ("GloriousColdbloodedTortoiseRuleFive-E017utJ4DZmHVpfQ", "https://www.twitch.tv/dracul1nx/clip/GloriousColdbloodedTortoiseRuleFive-E017utJ4DZmHVpfQ?filter=clips&range=7d&sort=time"),
 }
 
 

--- a/twitchdl/utils.py
+++ b/twitchdl/utils.py
@@ -69,9 +69,9 @@ VIDEO_PATTERNS = [
 ]
 
 CLIP_PATTERNS = [
-    r"^(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_]+)?)$",
-    r"^https://(www.)?twitch.tv/\w+/clip/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_]+)?)(\?.+)?$",
-    r"^https://clips.twitch.tv/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_]+)?)(\?.+)?$",
+    r"^(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_-]{16})?)$",
+    r"^https://(www.)?twitch.tv/\w+/clip/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_-]{16})?)(\?.+)?$",
+    r"^https://clips.twitch.tv/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_-]{16})?)(\?.+)?$",
 ]
 
 

--- a/twitchdl/utils.py
+++ b/twitchdl/utils.py
@@ -69,9 +69,9 @@ VIDEO_PATTERNS = [
 ]
 
 CLIP_PATTERNS = [
-    r"^(?P<slug>[A-Za-z0-9]+)$",
-    r"^https://(www.)?twitch.tv/\w+/clip/(?P<slug>[A-Za-z0-9]+)(\?.+)?$",
-    r"^https://clips.twitch.tv/(?P<slug>[A-Za-z0-9]+)(\?.+)?$",
+    r"^(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9]+)?)$",
+    r"^https://(www.)?twitch.tv/\w+/clip/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9]+)?)(\?.+)?$",
+    r"^https://clips.twitch.tv/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9]+)?)(\?.+)?$",
 ]
 
 

--- a/twitchdl/utils.py
+++ b/twitchdl/utils.py
@@ -69,9 +69,9 @@ VIDEO_PATTERNS = [
 ]
 
 CLIP_PATTERNS = [
-    r"^(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9]+)?)$",
-    r"^https://(www.)?twitch.tv/\w+/clip/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9]+)?)(\?.+)?$",
-    r"^https://clips.twitch.tv/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9]+)?)(\?.+)?$",
+    r"^(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_]+)?)$",
+    r"^https://(www.)?twitch.tv/\w+/clip/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_]+)?)(\?.+)?$",
+    r"^https://clips.twitch.tv/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_]+)?)(\?.+)?$",
 ]
 
 


### PR DESCRIPTION
Twitch changed the clip naming pattern, appending a dash, followed by a random ID (seemingly matching [A-Za-z0-9] over 16 chars, could not find official documentation/announcement on the change) to clip names.
Old clip names remain valid.
This adds a new non capturing optional group to the 3 patterns matching clips to match this new ID.