### PR TITLE
Fix ETA and speed calculation

### DIFF
--- a/twitchdl/download.py
+++ b/twitchdl/download.py
@@ -85,6 +85,7 @@ def _print_progress(futures):
             "at <cyan>{}/s</cyan>".format(format_size(speed)) if speed > 0 else "",
             "remaining <cyan>~{}</cyan>".format(format_duration(remaining)) if speed > 0 else "",
         ])
+        
         max_msg_size = max(len(msg), max_msg_size)
         print_out("\r" + msg.ljust(max_msg_size), end="")
 

--- a/twitchdl/download.py
+++ b/twitchdl/download.py
@@ -85,7 +85,7 @@ def _print_progress(futures):
             "at <cyan>{}/s</cyan>".format(format_size(speed)) if speed > 0 else "",
             "remaining <cyan>~{}</cyan>".format(format_duration(remaining)) if speed > 0 else "",
         ])
-        
+
         max_msg_size = max(len(msg), max_msg_size)
         print_out("\r" + msg.ljust(max_msg_size), end="")
 

--- a/twitchdl/download.py
+++ b/twitchdl/download.py
@@ -31,6 +31,7 @@ def _download(url, path):
     os.rename(tmp_path, path)
     return size
 
+
 def download_file(url, path, retries=RETRY_COUNT):
     if os.path.exists(path):
         from_disk = True
@@ -56,13 +57,13 @@ def _print_progress(futures):
     current_downloaded_count = 0
 
     for future in as_completed(futures):
-        results = future.result()
-        size, from_disk = results
+        size, from_disk = future.result()
         downloaded_count += 1
         downloaded_size += size
         
         if from_disk:
-            # If we find something on disk, then the download speed will be wrong
+            # If we find something on disk, we don't want to
+            # take it in account in the speed calculation
             start_time = datetime.now()
             current_download_size = 0
             current_downloaded_count = 0


### PR DESCRIPTION
Fix #75 
I love your work, thank you for creating this project. I don't like to create issues without trying to solve them, so here is my solution for the issue I posted.
I changed what is returned by the _download() function, in download.py, and the speed and ETA calculations in _print_progress().
Before, it took in account all the downloaded VODs to compute speed and ETA, but if you interrupt the program and relaunch it, it won't take in account the time used to download all the previously saved VODs. In other words, the script will consider we downloaded a lot of VODs in few seconds (but they actually were on the disk), and this error will impact the displayed speed during all the rest of the downloading.
Now, we distinguish data coming from disk (not to take in account in the speed and ETA calculation) and data coming from the internet (what we actually want to compute)
