### PR TITLE
Subscriber only VOD support via user auth token

### DIFF
--- a/docs/commands/download.md
+++ b/docs/commands/download.md
@@ -71,6 +71,11 @@ twitch-dl download <video> [FLAGS] [OPTIONS]
 </tr>
 
 <tr>
+    <td class="code">-a, --auth</td>
+    <td>Twitch authentication token needed for subscriber-only VODs. Can be found in the 'auth_token' cookie.</td>
+</tr>
+
+<tr>
     <td class="code">-o, --output</td>
     <td>Output file name template. See docs for details.</td>
 </tr>

--- a/twitchdl/commands/download.py
+++ b/twitchdl/commands/download.py
@@ -274,7 +274,7 @@ def _download_video(video_id, args):
         args.overwrite = True
 
     print_out("<dim>Fetching access token...</dim>")
-    access_token = twitch.get_access_token(video_id)
+    access_token = twitch.get_access_token(video_id, auth_token=args.auth)
 
     print_out("<dim>Fetching playlists...</dim>")
     playlists_m3u8 = twitch.get_playlists(video_id, access_token)

--- a/twitchdl/console.py
+++ b/twitchdl/console.py
@@ -176,6 +176,13 @@ COMMANDS = [
                 "help": "Video quality, e.g. 720p. Set to 'source' to get best quality.",
                 "type": str,
             }),
+            (["-a", "--auth"], {
+                "help": "Authentication token, passed to Twitch to access subscriber only "
+                        "VODs. Can be copied from the 'auth_token' cookie in any browser "
+                        "logged in on Twitch.",
+                "type": str,
+                "default": None,
+            }),
             (["--no-join"], {
                 "help": "Don't run ffmpeg to join the downloaded vods, implies --keep.",
                 "action": "store_true",

--- a/twitchdl/twitch.py
+++ b/twitchdl/twitch.py
@@ -52,9 +52,9 @@ def gql_post(query):
     return response
 
 
-def gql_query(query):
+def gql_query(query, headers={}):
     url = "https://gql.twitch.tv/gql"
-    response = authenticated_post(url, json={"query": query}).json()
+    response = authenticated_post(url, json={"query": query}, headers=headers).json()
 
     if "errors" in response:
         raise GQLError(response["errors"])
@@ -303,7 +303,7 @@ def channel_videos_generator(channel_id, max_videos, sort, type, game_ids=None):
     return videos["totalCount"], _generator(videos, max_videos)
 
 
-def get_access_token(video_id):
+def get_access_token(video_id, auth_token=None):
     query = """
     {{
         videoPlaybackAccessToken(
@@ -322,7 +322,11 @@ def get_access_token(video_id):
 
     query = query.format(video_id=video_id)
 
-    response = gql_query(query)
+    headers = {}
+    if auth_token is not None:
+        headers['authorization'] = f'OAuth {auth_token}'
+
+    response = gql_query(query, headers=headers)
     return response["data"]["videoPlaybackAccessToken"]
 
 


### PR DESCRIPTION
As requested in #48.

The simplest possible solution to downloading subscriber only VODs. Optionally passes a user authentication token along in the authorization header when loading the video access token. For this I added a new param to the download command (-a / -auth).

This solution sidesteps programmatic login entirely. The only "downside" is that the auth token has to be manually extracted from the cookies / the request header by the user.