### PR TITLE
Return printed values as well when using --json flag

### DIFF
--- a/twitchdl/commands/clips.py
+++ b/twitchdl/commands/clips.py
@@ -17,7 +17,9 @@ def clips(args):
     generator = twitch.channel_clips_generator(args.channel_name, args.period, limit)
 
     if args.json:
-        return print_json(list(generator))
+        data = list(generator)
+        print_json(data)
+        return data
 
     if args.download:
         return _download_clips(generator)

--- a/twitchdl/commands/info.py
+++ b/twitchdl/commands/info.py
@@ -22,7 +22,7 @@ def info(args):
 
         if video:
             if args.json:
-                video_json(video, playlists)
+                return video_json(video, playlists)
             else:
                 video_info(video, playlists)
             return
@@ -36,6 +36,7 @@ def info(args):
 
         if args.json:
             print_json(clip)
+            return clip
         else:
             clip_info(clip)
         return
@@ -67,6 +68,7 @@ def video_json(video, playlists):
     ]
 
     print_json(video)
+    return video
 
 
 def clip_info(clip):

--- a/twitchdl/commands/videos.py
+++ b/twitchdl/commands/videos.py
@@ -15,12 +15,13 @@ def videos(args):
 
     if args.json:
         videos = list(generator)
-        print_json({
+        data = {
             "count": len(videos),
             "totalCount": total_count,
             "videos": videos
-        })
-        return
+        }
+        print_json(data)
+        return data
 
     if total_count == 0:
         print_out("<yellow>No videos found</yellow>")

--- a/twitchdl/twitch.py
+++ b/twitchdl/twitch.py
@@ -281,7 +281,7 @@ def get_channel_videos(channel_id, limit, sort, type="archive", game_ids=[], aft
     return response["data"]["user"]["videos"]
 
 
-def channel_videos_generator(channel_id, max_videos, sort, type, game_ids=None):
+def channel_videos_generator(channel_id, max_videos, sort, type, game_ids=[]):
     def _generator(videos, max_videos):
         for video in videos["edges"]:
             if max_videos < 1:


### PR DESCRIPTION
Closes #95 

The change from `game_ids=None` to `game_ids=[]` is because `None` breaks the GraphQL query. If `channel_videos_generator` is being called without explicitly setting the named argument `game_ids`, `None` is being set, which is not compatible with the GraphQL query.