### PR TITLE
Removing positional-only arguments for compatibility with Python 3.7

### DIFF
--- a/twitchdl/http.py
+++ b/twitchdl/http.py
@@ -117,7 +117,7 @@ async def download_all(
     sources: List[str],
     targets: List[str],
     workers: int,
-    /, *,
+    *,
     rate_limit: Optional[int] = None
 ):
     progress = Progress(len(sources))


### PR DESCRIPTION
In readme it says that twitch-dl requires Python 3.7+ to run.
But it doesn't run under 3.7 because it's using positional-only arguments that one time, and they were introduced in Python 3.8 (https://peps.python.org/pep-0570/).
This change should not break the code in other places - arguments turn from strictly positional to keyword-or-positional, so all the current call-cites are OK.

Yes, it may make API of the function slightly worse (although I'd argue it's not), but but there are environments where getting python 3.8 is more complicated than opening a PR on Github 😉