### PR TITLE
Add sorting options for clips (ascending/descending for view-count and date)

### DIFF
--- a/twitchdl/commands/clips.py
+++ b/twitchdl/commands/clips.py
@@ -16,6 +16,15 @@ def clips(args):
 
     generator = twitch.channel_clips_generator(args.channel_name, args.period, limit)
 
+    if args.sort != "views-desc":
+        match args.sort:
+            case "views-asc":
+                generator = sorted(list(generator), key=lambda x: x['viewCount'])
+            case "date-desc":
+                generator = sorted(list(generator), key=lambda x: x['createdAt'], reverse=True)
+            case "date-asc":
+                generator = sorted(list(generator), key=lambda x: x['createdAt'])
+
     if args.json:
         return print_json(list(generator))
 

--- a/twitchdl/console.py
+++ b/twitchdl/console.py
@@ -87,7 +87,7 @@ COMMANDS = [
                 "type": str,
             }),
             (["-l", "--limit"], {
-                "help": "Number of videos to fetch. Defaults to 40 in copmpact mode, 10 otherwise.",
+                "help": "Number of videos to fetch. Defaults to 40 in compact mode, 10 otherwise.",
                 "type": pos_integer,
             }),
             (["-a", "--all"], {
@@ -142,6 +142,12 @@ COMMANDS = [
                 "help": "Fetch all videos, overrides --limit",
                 "action": "store_true",
                 "default": False,
+            }),
+            (["-s", "--sort"], {
+                "help": "Order in which to return clips. Defaults to `views-desc`.",
+                "type": str,
+                "choices": ["views-desc", "views-asc", "date-desc", "date-asc"],
+                "default": "views-desc",
             }),
             (["-P", "--period"], {
                 "help": "Period from which to return clips. Defaults to `all_time`.",


### PR DESCRIPTION
Twitch's gql API sucks and doesn't seem to support anything but VIEWS_DESC for the query. AFAIK the official stance for the public Helix API is to just sort the data yourself after getting it.

So, here we are.

Tested with `--json` and `--pager` as well as without. Haven't tested downloading but I don't see why that would break.

This does have poor performance when working with large numbers of clips (e.g. `--all` on channels with thousands of clips) since it has to first exhaust the generator before sorting. But until we can query the GQL API properly I don't see any way around it.

There's no performance impact to the default setting of sorting by view-count descending since the query response comes sorted that way already.

Should be noted that since the API returns clips sorted by View Count, the sorting method provided by `--sort` will only apply to the most-viewed clips unless you specify `--all`. So that may be a little confusing for end users.