### PR TITLE
Update get playlists endpoint URL

### DIFF
--- a/twitchdl/twitch.py
+++ b/twitchdl/twitch.py
@@ -335,7 +335,7 @@ def get_playlists(video_id, access_token):
     """
     For a given video return a playlist which contains possible video qualities.
     """
-    url = "http://usher.twitch.tv/vod/{}".format(video_id)
+    url = "http://usher.ttvnw.net/vod/{}".format(video_id)
 
     response = httpx.get(url, params={
         "nauth": access_token['value'],


### PR DESCRIPTION
The Twitch Usher URL has changed and the current version of twitch-dl does not work. This fix is taken from commit [5394c3f](https://github.com/lay295/TwitchDownloader/commit/5394c3f3247b32b664d4eaca6a75ed3ef5d6acbd) to lay265/TwitchDownloader.