### PR TITLE
Add feature to skip playlist downloads instead of aborting if a file exists

### DIFF
--- a/twitchdl/commands/download.py
+++ b/twitchdl/commands/download.py
@@ -245,11 +245,30 @@ def _download_clip(slug: str, args) -> None:
     target = _clip_target_filename(clip, args)
     print_out("Target: <blue>{}</blue>".format(target))
 
-    if not args.overwrite and path.exists(target):
-        response = input("File exists. Overwrite? [Y/n]: ")
-        if response.lower().strip() not in ["", "y"]:
-            raise ConsoleError("Aborted")
-        args.overwrite = True
+    if path.exists(target):
+        if args.skipall:
+            print("Target file exists. Skipping.")
+            return
+        if not args.overwrite:
+            while True:
+                response = input("File exists. Overwrite? [ \033[4mY\033[0mes, \033[4ma\033[0mlways yes, \033[4ms\033[0mkip, always s\033[4mk\033[0mip,  a\033[4mb\033[0mort ]: ")
+                match response.lower().strip():
+                    case "y":
+                        break # Just continue
+                    case "a":
+                        args.overwrite = True
+                        break
+                    case "s":
+                        print("Skipping.")
+                        return
+                    case "k":
+                        print("Skipping.")
+                        args.skipall  = True
+                        return
+                    case "b":
+                        raise ConsoleError("Aborted")
+                    case _:
+                        print("Invalid input.")
 
     url = get_clip_authenticated_url(slug, args.quality)
     print_out("<dim>Selected URL: {}</dim>".format(url))
@@ -276,11 +295,28 @@ def _download_video(video_id, args) -> None:
     target = _video_target_filename(video, args)
     print_out("Output: <blue>{}</blue>".format(target))
 
-    if not args.overwrite and path.exists(target):
-        response = input("File exists. Overwrite? [Y/n]: ")
-        if response.lower().strip() not in ["", "y"]:
-            raise ConsoleError("Aborted")
-        args.overwrite = True
+    if path.exists(target):
+        if args.skipall:
+            print("Target file exists. Skipping.")
+            return
+        if not args.overwrite:
+            while True:
+                response = input("File exists. Overwrite? [ \033[4mY\033[0mes, \033[4ma\033[0mlways yes, \033[4ms\033[0mkip, always s\033[4mk\033[0mip,  a\033[4mb\033[0mort ]: ")
+                match response.lower().strip():
+                    case "y":
+                        break # Just continue
+                    case "a":
+                        args.overwrite = True
+                        break
+                    case "s":
+                        return
+                    case "k":
+                        args.skipall  = True
+                        return
+                    case "b":
+                        raise ConsoleError("Aborted")
+                    case _:
+                        print("Invalid input.")
 
     # Chapter select or manual offset
     start, end = _determine_time_range(video_id, args)

--- a/twitchdl/commands/download.py
+++ b/twitchdl/commands/download.py
@@ -251,7 +251,7 @@ def _download_clip(slug: str, args) -> None:
             return
         if not args.overwrite:
             while True:
-                response = input("File exists. Overwrite? [ \033[4mY\033[0mes, \033[4ma\033[0mlways yes, \033[4ms\033[0mkip, always s\033[4mk\033[0mip,  a\033[4mb\033[0mort ]: ")
+                response = input("File exists. Overwrite? [ \033[4mY\033[0mes, \033[4ma\033[0mlways yes, \033[4ms\033[0mkip, always s\033[4mk\033[0mip, a\033[4mb\033[0mort ]: ")
                 match response.lower().strip():
                     case "y":
                         break # Just continue
@@ -301,7 +301,7 @@ def _download_video(video_id, args) -> None:
             return
         if not args.overwrite:
             while True:
-                response = input("File exists. Overwrite? [ \033[4mY\033[0mes, \033[4ma\033[0mlways yes, \033[4ms\033[0mkip, always s\033[4mk\033[0mip,  a\033[4mb\033[0mort ]: ")
+                response = input("File exists. Overwrite? [ \033[4mY\033[0mes, \033[4ma\033[0mlways yes, \033[4ms\033[0mkip, always s\033[4mk\033[0mip, a\033[4mb\033[0mort ]: ")
                 match response.lower().strip():
                     case "y":
                         break # Just continue

--- a/twitchdl/console.py
+++ b/twitchdl/console.py
@@ -218,6 +218,11 @@ COMMANDS = [
                 "action": "store_true",
                 "default": False,
             }),
+            (["--skipall"], {
+                "help": "Skip the current file if it already exists without prompting.",
+                "action": "store_true",
+                "default": False,
+            }),
             (["--overwrite"], {
                 "help": "Overwrite the target file if it already exists without prompting.",
                 "action": "store_true",

--- a/twitchdl/utils.py
+++ b/twitchdl/utils.py
@@ -92,7 +92,7 @@ VIDEO_PATTERNS = [
 CLIP_PATTERNS = [
     r"^(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_-]{16})?)$",
     r"^https://(www.)?twitch.tv/\w+/clip/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_-]{16})?)(\?.+)?$",
-    r"^https://clips.twitch.tv/(?P<slug>[A-Za-z0-9]+(?:-[A-Za-z0-9_-]{16})?)(\?.+)?$",
+    r"^https://clips.twitch.tv/(?P<slug>[A-Za-z0-9-]+(?:-[A-Za-z0-9_-]{16})?)(\?.+)?$",
 ]
 
 


### PR DESCRIPTION
Addresses #136

When trying to download multiple videos by ID, and a file exists, it asks `File exists. Overwrite? [Y/n]:` and if the user chooses 'n' then it aborts everything.

This PR adds the following options, to replace the existing Y/n options:
`File exists. Overwrite? [ Yes, always yes, skip, always skip, abort ]:`

"Skip" will skip the current file, and the user will be prompted again next time. "Always skip" will skip all future files without prompting the user. "n" has been changed to "abort," and "always yes" enables the --overwrite flag and continues as normal.

I believe this will streamline the process when someone wants to download several videos at once, but one or two videos in the middle already exist, or if they want to make sure all the videos in a list are downloaded, but only one or two are actually missing.