### PR TITLE
Add --dry-run option

### DIFF
--- a/twitchdl/commands/download.py
+++ b/twitchdl/commands/download.py
@@ -255,7 +255,9 @@ def _download_clip(slug: str, args) -> None:
     print_out("<dim>Selected URL: {}</dim>".format(url))
 
     print_out("<dim>Downloading clip...</dim>")
-    download_file(url, target)
+
+    if (args.dry_run is False):
+        download_file(url, target)
 
     print_out("Downloaded: <blue>{}</blue>".format(target))
 

--- a/twitchdl/console.py
+++ b/twitchdl/console.py
@@ -240,6 +240,12 @@ COMMANDS = [
                 "nargs": "?",
                 "const": 0
             }),
+            (["-d", "--dry-run"], {
+                "help": "argument provides users with a simulation mode, them to "
+                        "preview the download process without actually downloading any files",
+                "action": "store_true",
+                "default": False,
+            }),
         ],
     ),
     Command(


### PR DESCRIPTION
The `--dry-run` argument for `twitch-dl` provides users with a simulation mode, allowing them to preview the download process without actually downloading any files. When this option is invoked using either the -d or --dry-run flags, `twitch-dl` will perform a dry run by simulating the entire download workflow

