### PR TITLE
Fix issue #155 by adding quotes to gql query

### DIFF
--- a/twitchdl/twitch.py
+++ b/twitchdl/twitch.py
@@ -422,7 +422,7 @@ def get_access_token(video_id: str, auth_token: Optional[str] = None) -> AccessT
     query = f"""
     {{
         videoPlaybackAccessToken(
-            id: {video_id},
+            id: "{video_id}",
             params: {{
                 platform: "web",
                 playerBackend: "mediaplayer",


### PR DESCRIPTION
Fixes https://github.com/ihabunek/twitch-dl/issues/155

Twitch video IDs recently surpassed the range of an int32, so the IDs must now be provided as a string in GraphQL queries.
This was already being done in [twitch.get_video()](https://github.com/ihabunek/twitch-dl/blob/47d62bc4710399ca40b63130d829874094ccf9c6/twitchdl/twitch.py#L217), however it was missing from [twitch.get_access_token()](https://github.com/ihabunek/twitch-dl/blob/47d62bc4710399ca40b63130d829874094ccf9c6/twitchdl/twitch.py#L425) so this PR fixes that.