### PR TITLE
WIP: support subscriber-only videos via fake playlist

### DIFF
--- a/twitchdl/commands/info.py
+++ b/twitchdl/commands/info.py
@@ -4,12 +4,12 @@ import click
 import m3u8
 
 from twitchdl import twitch, utils
-from twitchdl.exceptions import ConsoleError
+from twitchdl.exceptions import ConsoleError, PlaylistAuthRequireError
 from twitchdl.naming import video_placeholders
 from twitchdl.output import bold, dim, print_clip, print_json, print_log, print_table, print_video
 from twitchdl.playlists import parse_playlists
 from twitchdl.twitch import Chapter, Clip, Video
-
+from twitchdl.playlists_auth import fetch_auth_playlist
 
 def info(id: str, *, json: bool = False, auth_token: Optional[str]):
     video_id = utils.parse_video_identifier(id)
@@ -24,7 +24,11 @@ def info(id: str, *, json: bool = False, auth_token: Optional[str]):
         access_token = twitch.get_access_token(video_id, auth_token)
 
         print_log("Fetching playlists...")
-        playlists = twitch.get_playlists(video_id, access_token)
+        try:
+            playlists = twitch.get_playlists(video["id"], access_token)
+        except PlaylistAuthRequireError:
+            print_log("Possible subscriber-only try via fake playlist")
+            playlists = fetch_auth_playlist(video["id"])
 
         print_log("Fetching chapters...")
         chapters = twitch.get_video_chapters(video_id)

--- a/twitchdl/exceptions.py
+++ b/twitchdl/exceptions.py
@@ -5,3 +5,8 @@ class ConsoleError(click.ClickException):
     """Raised when an error occurs and script exectuion should halt."""
 
     pass
+
+class PlaylistAuthRequireError(Exception):
+    """Raised when playlist auth requirement is missing."""
+
+    pass

--- a/twitchdl/http.py
+++ b/twitchdl/http.py
@@ -82,7 +82,11 @@ async def download(
     tmp_target = f"{target}.tmp"
     with open(tmp_target, "wb") as f:
         async with client.stream("GET", source) as response:
-            size = int(response.headers.get("content-length"))
+            content_length = response.headers.get("content-length")
+            if content_length is None:
+                raise ConsoleError('No content length: {}'.format(source))
+
+            size = int(content_length)
             progress.start(task_id, size)
             async for chunk in response.aiter_bytes(chunk_size=CHUNK_SIZE):
                 f.write(chunk)

--- a/twitchdl/playlists_auth.py
+++ b/twitchdl/playlists_auth.py
@@ -1,0 +1,103 @@
+import httpx
+from datetime import datetime
+import random
+from urllib.parse import urlparse
+from twitchdl.exceptions import ConsoleError
+from twitchdl.twitch import gql_query
+
+def fetch_twitch_data_gql(vod_id):
+    query = f'query {{ video(id: "{vod_id}") {{ broadcastType, createdAt, seekPreviewsURL, owner {{ login }} }} }}'
+    return gql_query(query)
+
+def create_serving_id():
+    chars = "0123456789abcdefghijklmnopqrstuvwxyz"
+    return ''.join(random.choice(chars) for _ in range(32))
+
+def is_valid_quality(url):
+    with httpx.Client() as client:
+        response = client.get(url)
+        if response.status_code == 200:
+            data = response.text
+            if ".ts" in data:
+                return {"codec": "avc1.4D001E"}
+            elif ".mp4" in data:
+                mp4_url = url.replace("index-dvr.m3u8", "init-0.mp4")
+                mp4_response = client.get(mp4_url)
+                if mp4_response.status_code == 200:
+                    content = mp4_response.text
+                    return {"codec": "hev1.1.6.L93.B0" if "hev1" in content else "avc1.4D001E"}
+                return {"codec": "hev1.1.6.L93.B0"}
+    return None
+
+def fetch_auth_playlist(vod_id):
+    data = fetch_twitch_data_gql(vod_id)
+
+    if not data:
+        raise ConsoleError('Invalid vodId')
+
+    vod_data = data['data']['video']
+    channel_data = vod_data['owner']
+
+    resolutions = {
+        "audio_only": {"res": "audio_only"},
+        "160p30": {"res": "284x160", "fps": 30},
+        "360p30": {"res": "640x360", "fps": 30},
+        "480p30": {"res": "854x480", "fps": 30},
+        "720p60": {"res": "1280x720", "fps": 60},
+        "1080p60": {"res": "1920x1080", "fps": 60},
+        "chunked": {"res": "1920x1080", "fps": 60}
+    }
+
+    sorted_keys = sorted(resolutions.keys(), reverse=True)
+    ordered_resolutions = {key: resolutions[key] for key in sorted_keys}
+
+    current_url = urlparse(vod_data['seekPreviewsURL'])
+    domain = current_url.hostname
+    paths = current_url.path.split('/')
+    vod_special_id = paths[paths.index(next(p for p in paths if "storyboards" in p)) - 1]
+
+    fake_playlist = f'''#EXTM3U
+#EXT-X-TWITCH-INFO:ORIGIN="s3",B="false",REGION="EU",USER-IP="127.0.0.1",SERVING-ID="{create_serving_id()}",CLUSTER="cloudfront_vod",USER-COUNTRY="BE",MANIFEST-CLUSTER="cloudfront_vod"'''
+
+    now = datetime.strptime("2023-02-10", "%Y-%m-%d")
+    created = datetime.strptime(vod_data['createdAt'], "%Y-%m-%dT%H:%M:%SZ")
+    time_difference = (now - created).total_seconds()
+    days_difference = time_difference / (3600 * 24)
+
+    broadcast_type = vod_data['broadcastType'].lower()
+    start_quality = 8534030
+
+    for res_key, res_value in ordered_resolutions.items():
+        url = None
+
+        if broadcast_type == "highlight":
+            url = f"https://{domain}/{vod_special_id}/{res_key}/highlight-{vod_id}.m3u8"
+        elif broadcast_type == "upload" and days_difference > 7:
+            url = f"https://{domain}/{channel_data['login']}/{vod_id}/{vod_special_id}/{res_key}/index-dvr.m3u8"
+        else:
+            url = f"https://{domain}/{vod_special_id}/{res_key}/index-dvr.m3u8"
+
+        if not url:
+            continue
+
+        result = is_valid_quality(url)
+        if result:
+            quality = res_value['res'].split('x')[1] + "p" if res_key == "chunked" else res_key
+            enabled = "YES" if res_key == "chunked" else "NO"
+            fps = res_value.get('fps', 0)
+
+            if quality == 'audio_only':
+                fake_playlist += f'''
+#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="{quality}",NAME="{quality}",AUTOSELECT={enabled},DEFAULT={enabled}
+#EXT-X-STREAM-INF:BANDWIDTH={start_quality},CODECS="{result['codec']},mp4a.40.2",VIDEO="{quality}"
+{url}'''
+            else:
+                name = quality if fps != 30 else quality[:-2]
+                fake_playlist += f'''
+#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="{quality}",NAME="{name}",AUTOSELECT={enabled},DEFAULT={enabled}
+#EXT-X-STREAM-INF:BANDWIDTH={start_quality},CODECS="{result['codec']},mp4a.40.2",RESOLUTION={res_value['res']},VIDEO="{quality}",FRAME-RATE={fps}
+{url}'''
+
+            start_quality -= 100
+
+    return fake_playlist

--- a/twitchdl/twitch.py
+++ b/twitchdl/twitch.py
@@ -24,7 +24,7 @@ from twitchdl.entities import (
     VideosSort,
     VideosType,
 )
-from twitchdl.exceptions import ConsoleError
+from twitchdl.exceptions import ConsoleError, PlaylistAuthRequireError
 from twitchdl.utils import format_size, remove_null_values
 
 
@@ -414,7 +414,7 @@ def get_access_token(video_id: str, auth_token: Optional[str] = None) -> AccessT
             if auth_token:
                 raise ConsoleError("Unauthorized. The provided auth token is not valid.")
             else:
-                raise ConsoleError(UNAUTHORIZED_ERROR)
+                raise PlaylistAuthRequireError(UNAUTHORIZED_ERROR)
 
         raise
 
@@ -442,7 +442,7 @@ def get_playlists(video_id: str, access_token: AccessToken) -> str:
         return response.content.decode("utf-8")
     except httpx.HTTPStatusError as ex:
         if ex.response.status_code == 403:
-            raise ConsoleError(UNAUTHORIZED_ERROR)
+            raise PlaylistAuthRequireError(UNAUTHORIZED_ERROR)
         raise
 
 


### PR DESCRIPTION
This allows downloading subscribers only twitch videos, via a "fake playlist". Patch was running against 1000th hours of videos and therefore tweaked against real world cases.

```
twitchdl download 2410622392 --quality=audio_only
```

```
Looking up video...
Found video: [LuckyV.de 💛] 🌴 Ab ins Abenteuerland || GTA Roleplay & Rainbow Six || !siegeX Beta || !drops by Heideltraut playing Grand Theft Auto V (08:03:42)
Target: 2025-03-20_2410622392_heideltraut_luckyvde_ab_ins_abenteuerland_gta_roleplay_rainbow_six_siegex_beta_drops.mkv
Fetching chapters...
Fetching access token...
Fetching playlists...
Possible subscriber-only try via fake playlist
Fetching playlist...
Downloading to cache: /home/daniel/.cache/twitch-dl/videos/2410622392/audio_only
Downloading 2894 VODs using 10 workers
Downloaded 12/2894 VODs 0% of ~611.2MB at 8.3MB/s ETA 01:12
```

Info command is supported, showing only available qualities:

```
python -m twitchdl info 2411515859
```

```
1080p       1080p       1920x1080   https://[...]/index-dvr.m3u8
audio_only  audio_only  None        https://[...]/index-dvr.m3u8
720p60      720p60      1280x720    https://[...]/index-dvr.m3u8
480p        480p30      854x480     https://[...]/index-dvr.m3u8
360p        360p30      640x360     https://[...]/index-dvr.m3u8
160p        160p30      284x160     https://[...]/index-dvr.m3u8
```

Muted segments are support, they provide empty content chunks, which would break process; resolved by using muted segments

```
twitchdl download 2411515859 --quality=audio_only
```

Main logic was extracted from: https://github.com/besuper/TwitchNoSub/blob/master/src/patch_amazonworker.js



